### PR TITLE
Fix small typo: Use get_stylesheet_directory_uri()

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ new WordpressViteAssets(string $manifestPath, string $baseUri, string $algorithm
 
 use Idleberg\WordpressViteAssets\WordpressViteAssets;
 
-$baseUrl = get_stylesheet_directory();
+$baseUrl = get_stylesheet_directory_uri();
 $manifest = "path/to/manifest.json";
 $entryPoint = "index.ts";
 


### PR DESCRIPTION
### Description of the Change

`get_stylesheet_directory()` outputs a internal file path, but for base url `get_stylesheet_directory_uri()` is the correct function (and works in my local test setup). 

### Release Notes

Fix function mentioned in docs: Use `get_stylesheet_directory_uri()` for baseUrl setting

https://developer.wordpress.org/reference/functions/get_stylesheet_directory_uri/

(Thanks for providing as open source! 👍 👍 Used in https://github.com/mandrasch/ddev-wp-vite-demo)