### PR TITLE
Updated to support scss

### DIFF
--- a/src/Assets.php
+++ b/src/Assets.php
@@ -70,7 +70,7 @@ class Assets
 
         add_action($action, function () use ($entries, $options) {
             array_map(function($entry) use ($options) {
-                $tag = str_ends_with($entry, 'css')
+                $tag = str_ends_with($entry, '.css') || str_ends_with($entry, '.scss')
                     ? array_key_first($this->getStyleTags($entry, $options))
                     : $this->getScriptTag($entry, $options);
 

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -70,7 +70,7 @@ class Assets
 
         add_action($action, function () use ($entries, $options) {
             array_map(function($entry) use ($options) {
-                $tag = str_ends_with($entry, '.css')
+                $tag = str_ends_with($entry, 'css')
                     ? array_key_first($this->getStyleTags($entry, $options))
                     : $this->getScriptTag($entry, $options);
 


### PR DESCRIPTION
Manifest contains files with .scss filenames, meaning that the styles are adding script modules too.

```
$baseUrl  = get_template_directory_uri() . '/dist/';
$manifest = get_template_directory() . "/dist/.vite/manifest.json";

$cssEntry = "assets/styles/main.scss";

$viteAssets = new Assets($manifest, $baseUrl);
$viteAssets->inject($cssEntry);
```

The above was outputting

```
<script type="module" src="https://project.test/wp-content/themes/tvw/dist/assets/main-C0ut9XiX.css" crossorigin integrity="sha256-uiuQruCDBu1DLYx6wlb32UAW7NhKG3rtUPv2Hf2R+Q8="></script>
<link rel="stylesheet" href="https://project.test/wp-content/themes/tvw/dist/assets/main-C0ut9XiX.css" crossorigin integrity="sha256-uiuQruCDBu1DLYx6wlb32UAW7NhKG3rtUPv2Hf2R+Q8=" />
```

because it was looking for files ending in .css which the manifest had .scss.